### PR TITLE
Use HTTPS for embedded video

### DIFF
--- a/index.md
+++ b/index.md
@@ -34,7 +34,7 @@ Learn more about Relax-and-Recover from the selected usage scenarios below:
 
 Or watch a 4-minute complete backup and restore demo. Real time, no cheating!
 
-<iframe width="720" height="400" src="http://www.youtube.com/embed/33326XobwYg" ><p>Relax-and-Recover video</p></iframe>
+<iframe width="720" height="400" src="//www.youtube.com/embed/33326XobwYg" ><p>Relax-and-Recover video</p></iframe>
 
 Try Relax-and-Recover now. The [Quickstart guide](http://relax-and-recover.org/documentation/getting-started) takes only a few minutes!
 


### PR DESCRIPTION
Modern browsers block content from mixed (HTTP/HTTPS) sources.
Since many modern browsers, or browser's security-enhancement extensions try to default to a HTTPS connection, for those users, the embedded youtube video wasn't visible, at all. These users, when opening the browser console, could see an error message like 'Blocked loading mixed active content “http://www.youtube.com/embed/33326XobwYg”'
This commit changes the embedded video link such that it uses whatever connection type (HTTP/HTTPS) was established to load the site's contents, and uses the same type of connection to load the embedded video, so that a "mixed content" is avoided.