### PR TITLE
Generic ReaR package download URLs

### DIFF
--- a/download/index.md
+++ b/download/index.md
@@ -45,130 +45,23 @@ ReaR is not part anymore of EPEL as it is now part of the distribution repositor
     zypper install rear
 
 
-### OpenSUSE Build Service packages
+### openSUSE Build Service packages
 If you are looking for newer stable release or snapshot release, take a look at
-our automated builds from the OpenSUSE Build Service:
+our automated builds from the openSUSE Build Service project Archiving:Backup:Rear
 
-#### Official stable releases
-Since rear release 1.17.2 you will find the stable packages under the architecture directory, e.g. *i586* or *x86_64* instead of *noarch*. Previous release are still kept under the *noarch* sub-directory.
+https://build.opensuse.org/project/show/Archiving:Backup:Rear
 
- * CentOS:
-    [5.0](http://download.opensuse.org/repositories/Archiving:/Backup:/Rear/CentOS_CentOS-5/),
-    [6.0](http://download.opensuse.org/repositories/Archiving:/Backup:/Rear/CentOS_CentOS-6/),
-    [7.0](http://download.opensuse.org/repositories/Archiving:/Backup:/Rear/CentOS_7/),
-    [8.0](http://download.opensuse.org/repositories/Archiving:/Backup:/Rear/CentOS_8/)
- * Debian:
-    [7.0](http://download.opensuse.org/repositories/Archiving:/Backup:/Rear/Debian_7.0/),
-    [8.0](http://download.opensuse.org/repositories/Archiving:/Backup:/Rear/Debian_8.0/),
-    [9.0](http://download.opensuse.org/repositories/Archiving:/Backup:/Rear/Debian_9.0/),
-    [10.0](http://download.opensuse.org/repositories/Archiving:/Backup:/Rear/Debian_10/)
-    [@debian](https://tracker.debian.org/pkg/rear)
- * Fedora:
-    [32](http://download.opensuse.org/repositories/Archiving:/Backup:/Rear/Fedora_32/),
-    [33](http://download.opensuse.org/repositories/Archiving:/Backup:/Rear/Fedora_33/)
- * openSUSE:
-    [Factory](http://download.opensuse.org/repositories/Archiving:/Backup:/Rear/openSUSE_Factory/),
-    [Factory_PowerPC](http://download.opensuse.org/repositories/Archiving:/Backup:/Rear/openSUSE_Factory_PowerPC/),
-    [Leap_15.2](http://download.opensuse.org/repositories/Archiving:/Backup:/Rear/openSUSE_Leap_15.2/),
-    [Leap_15.2_PowerPC](http://download.opensuse.org/repositories/Archiving:/Backup:/Rear/openSUSE_Leap_15.2_PowerPC/),
-    [Leap_15.3](http://download.opensuse.org/repositories/Archiving:/Backup:/Rear/openSUSE_Leap_15.3/),
-    [Tumbleweed](http://download.opensuse.org/repositories/Archiving:/Backup:/Rear/openSUSE_Tumbleweed/),
-    [Factory_PowerPC](http://download.opensuse.org/repositories/Archiving:/Backup:/Rear:/Snapshot/openSUSE_Factory_PowerPC/)
- * RHEL:
-    [5](http://download.opensuse.org/repositories/Archiving:/Backup:/Rear/RedHat_RHEL-5/),
-    [6](http://download.opensuse.org/repositories/Archiving:/Backup:/Rear/RedHat_RHEL-6/),
-    [7](http://download.opensuse.org/repositories/Archiving:/Backup:/Rear/RHEL_7/)
- * ScientificLinux:
-    [6](http://download.opensuse.org/repositories/Archiving:/Backup:/Rear/ScientificLinux_6/),
-    [7](http://download.opensuse.org/repositories/Archiving:/Backup:/Rear/ScientificLinux_7/)
- * SLES:
-    [11](http://download.opensuse.org/repositories/Archiving:/Backup:/Rear/SLE_11/),
-    [11_SP4](http://download.opensuse.org/repositories/Archiving:/Backup:/Rear/SLE_11_SP4/),
-    [12](http://download.opensuse.org/repositories/Archiving:/Backup:/Rear/SLE_12/),
-    [12_SP5](http://download.opensuse.org/repositories/Archiving:/Backup:/Rear/SLE_12_SP5/),
-    [15](http://download.opensuse.org/repositories/Archiving:/Backup:/Rear/SLE_15/),
-    [15_SP2](http://download.opensuse.org/repositories/Archiving:/Backup:/Rear/SLE_15_SP2/),
-    [15_SP3](http://download.opensuse.org/repositories/Archiving:/Backup:/Rear/SLE_15_SP3/)
- * Ubuntu:
-    [16.04](http://download.opensuse.org/repositories/Archiving:/Backup:/Rear/xUbuntu_16.04/),
-    [16.10](http://download.opensuse.org/repositories/Archiving:/Backup:/Rear/xUbuntu_16.10/),
-    [17.04](http://download.opensuse.org/repositories/Archiving:/Backup:/Rear/xUbuntu_17.04/),
-    [17.10](http://download.opensuse.org/repositories/Archiving:/Backup:/Rear/xUbuntu_17.10/),
-    [18.04](http://download.opensuse.org/repositories/Archiving:/Backup:/Rear/xUbuntu_18.04/),
-    [19.04](http://download.opensuse.org/repositories/Archiving:/Backup:/Rear/xUbuntu_19.04/),
-    [19.10](http://download.opensuse.org/repositories/Archiving:/Backup:/Rear/xUbuntu_19.10/),
-    [20.04](http://download.opensuse.org/repositories/Archiving:/Backup:/Rear/xUbuntu_20.04/),
-    [20.10](http://download.opensuse.org/repositories/Archiving:/Backup:/Rear/xUbuntu_20.10/),
-    [@ubuntu](https://launchpad.net/ubuntu/+source/rear)
- * Gentoo:
-    [@gentoo](https://packages.gentoo.org/package/app-backup/rear)
+To get ReaR packages from the openSUSE Build Service go to
 
-#### Snapshot releases from Git
+https://software.opensuse.org/package/rear
 
- * CentOS:
-    [6.0](http://download.opensuse.org/repositories/Archiving:/Backup:/Rear:/Snapshot/CentOS_CentOS-6/),
-    [7.0](http://download.opensuse.org/repositories/Archiving:/Backup:/Rear:/Snapshot/CentOS_7/)
-    [8.0](http://download.opensuse.org/repositories/Archiving:/Backup:/Rear:/Snapshot/CentOS_8/)
- * Debian:
-    [7.0](http://download.opensuse.org/repositories/Archiving:/Backup:/Rear:/Snapshot/Debian_7.0/amd64/),
-    [8.0](http://download.opensuse.org/repositories/Archiving:/Backup:/Rear:/Snapshot/Debian_8.0/amd64/),
-    [9.0](http://download.opensuse.org/repositories/Archiving:/Backup:/Rear:/Snapshot/Debian_9.0/amd64/)
-    [10.0](http://download.opensuse.org/repositories/Archiving:/Backup:/Rear:/Snapshot/Debian_10/amd64/)
- * Fedora:
-    [32](http://download.opensuse.org/repositories/Archiving:/Backup:/Rear:/Snapshot/Fedora_32/x86_64/),
-    [33](http://download.opensuse.org/repositories/Archiving:/Backup:/Rear:/Snapshot/Fedora_33/x86_64/),
-    [Rawhide](http://download.opensuse.org/repositories/Archiving:/Backup:/Rear:/Snapshot/Fedora_Rawhide/)
- * openSUSE:
-    [13.1](http://download.opensuse.org/repositories/Archiving:/Backup:/Rear:/Snapshot/openSUSE_13.1/),
-    [13.2](http://download.opensuse.org/repositories/Archiving:/Backup:/Rear:/Snapshot/openSUSE_13.2/),
-    [Factory](http://download.opensuse.org/repositories/Archiving:/Backup:/Rear:/Snapshot/openSUSE_Factory/),
-    [Factory_PowerPC](http://download.opensuse.org/repositories/Archiving:/Backup:/Rear:/Snapshot/openSUSE_Factory_PowerPC/),
-    [Tumbleweed](http://download.opensuse.org/repositories/Archiving:/Backup:/Rear:/Snapshot/openSUSE_Tumbleweed/),
-    [Leap_42.2](http://download.opensuse.org/repositories/Archiving:/Backup:/Rear:/Snapshot/openSUSE_Leap_42.2/),
-    [Leap_42.3](http://download.opensuse.org/repositories/Archiving:/Backup:/Rear:/Snapshot/openSUSE_Leap_42.3/),
-    [Leap_15.0](http://download.opensuse.org/repositories/Archiving:/Backup:/Rear:/Snapshot/openSUSE_Leap_15.0/),
-    [Leap_15.1](http://download.opensuse.org/repositories/Archiving:/Backup:/Rear:/Snapshot/openSUSE_Leap_15.1/),
-    [Leap_15.2](http://download.opensuse.org/repositories/Archiving:/Backup:/Rear:/Snapshot/openSUSE_Leap_15.2/),
-    [Leap_15.3](http://download.opensuse.org/repositories/Archiving:/Backup:/Rear:/Snapshot/openSUSE_Leap_15.3/)
- * RHEL:
-    [5](http://download.opensuse.org/repositories/Archiving:/Backup:/Rear:/Snapshot/RedHat_RHEL-5/),
-    [6](http://download.opensuse.org/repositories/Archiving:/Backup:/Rear:/Snapshot/RedHat_RHEL-6/),
-    [7](http://download.opensuse.org/repositories/Archiving:/Backup:/Rear:/Snapshot/RHEL_7/)
- * ScientificLinux:
-    [6](http://download.opensuse.org/repositories/Archiving:/Backup:/Rear:/Snapshot/ScientificLinux_6/),
-    [7](http://download.opensuse.org/repositories/Archiving:/Backup:/Rear:/Snapshot/ScientificLinux_7/)
- * SLES:
-    [10](http://download.opensuse.org/repositories/Archiving:/Backup:/Rear:/Snapshot/SLE_10_SDK/),
-    [11](http://download.opensuse.org/repositories/Archiving:/Backup:/Rear:/Snapshot/SLE_11/),
-    [11_SP1](http://download.opensuse.org/repositories/Archiving:/Backup:/Rear:/Snapshot/SLE_11_SP1/),
-    [11_SP2](http://download.opensuse.org/repositories/Archiving:/Backup:/Rear:/Snapshot/SLE_11_SP2/),
-    [11_SP3](http://download.opensuse.org/repositories/Archiving:/Backup:/Rear:/Snapshot/SLE_11_SP3/),
-    [11_SP4](http://download.opensuse.org/repositories/Archiving:/Backup:/Rear:/Snapshot/SLE_11_SP4/),
-    [12](http://download.opensuse.org/repositories/Archiving:/Backup:/Rear:/Snapshot/SLE_12/),
-    [12_SP1](http://download.opensuse.org/repositories/Archiving:/Backup:/Rear:/Snapshot/SLE_12_SP1/),
-    [12_SP2](http://download.opensuse.org/repositories/Archiving:/Backup:/Rear:/Snapshot/SLE_12_SP2/),
-    [12_SP3](http://download.opensuse.org/repositories/Archiving:/Backup:/Rear:/Snapshot/SLE_12_SP3/),
-    [12_SP4](http://download.opensuse.org/repositories/Archiving:/Backup:/Rear:/Snapshot/SLE_12_SP4/),
-    [12_SP5](http://download.opensuse.org/repositories/Archiving:/Backup:/Rear:/Snapshot/SLE_12_SP4/),
-    [15](http://download.opensuse.org/repositories/Archiving:/Backup:/Rear:/Snapshot/SLE_15/),
-    [15_SP1](http://download.opensuse.org/repositories/Archiving:/Backup:/Rear:/Snapshot/SLE_15_SP1/),
-    [15_SP2](http://download.opensuse.org/repositories/Archiving:/Backup:/Rear:/Snapshot/SLE_15_SP2/),
-    [15_SP3](http://download.opensuse.org/repositories/Archiving:/Backup:/Rear:/Snapshot/SLE_15_SP3/)
- * Ubuntu:
-    [12.04](http://download.opensuse.org/repositories/Archiving:/Backup:/Rear:/Snapshot/xUbuntu_12.04/amd64/),
-    [14.04](http://download.opensuse.org/repositories/Archiving:/Backup:/Rear:/Snapshot/xUbuntu_14.04/amd64/),
-    [16.04](http://download.opensuse.org/repositories/Archiving:/Backup:/Rear:/Snapshot/xUbuntu_16.04/amd64/),
-    [16.10](http://download.opensuse.org/repositories/Archiving:/Backup:/Rear:/Snapshot/xUbuntu_16.10/amd64/),
-    [17.04](http://download.opensuse.org/repositories/Archiving:/Backup:/Rear:/Snapshot/xUbuntu_17.04/amd64/),
-    [17.10](http://download.opensuse.org/repositories/Archiving:/Backup:/Rear:/Snapshot/xUbuntu_17.10/amd64/),
-    [18.04](http://download.opensuse.org/repositories/Archiving:/Backup:/Rear:/Snapshot/xUbuntu_18.04/amd64/),
-    [18.10](http://download.opensuse.org/repositories/Archiving:/Backup:/Rear:/Snapshot/xUbuntu_18.10/amd64/),
-    [19.04](http://download.opensuse.org/repositories/Archiving:/Backup:/Rear:/Snapshot/xUbuntu_19.04/amd64/),
-    [19.10](http://download.opensuse.org/repositories/Archiving:/Backup:/Rear:/Snapshot/xUbuntu_19.10/amd64/),
-    [20.04](http://download.opensuse.org/repositories/Archiving:/Backup:/Rear:/Snapshot/xUbuntu_20.04/amd64/),
-    [20.10](http://download.opensuse.org/repositories/Archiving:/Backup:/Rear:/Snapshot/xUbuntu_20.10/amd64/)
-    [21.04](http://download.opensuse.org/repositories/Archiving:/Backup:/Rear:/Snapshot/xUbuntu_21.04/amd64/)
-    [21.10](http://download.opensuse.org/repositories/Archiving:/Backup:/Rear:/Snapshot/xUbuntu_21.10/amd64/)
+or for maual selection of a specific ReaR package for a particular Linux distribution start at
+
+http://download.opensuse.org/repositories/Archiving:/Backup:/Rear/
+
+for example ReaR packages for openSUSE Leap 15.4 and SLES15 SP4 for x86_64 architecture are at
+
+http://download.opensuse.org/repositories/Archiving:/Backup:/Rear/15.4/x86_64/
 
 
 ### Future releases


### PR DESCRIPTION
Cleanup of the "openSUSE Build Service packages" section on
https://relax-and-recover.org/download/

Replaced (mostly outdated) long lists of individual package URLs
by generic URLs that should work (hopefully) stable
while the individual openSUSE Build Service package URLs
change over time (changes in Linux distributions and versions).

Currently I don't know what to document about with
https://build.opensuse.org/project/show/Archiving:Backup:Rear:Snapshot
that seems to no longer do automated snapshots
(current latest change is 4 month ago).