### PR TITLE
Update relax-and-recover.org/support/ page

### DIFF
--- a/development/index.md
+++ b/development/index.md
@@ -10,21 +10,14 @@ issue tracking and this website.
 Rear is fully developed with the bash language and we follow the [coding styling described on the rear wiki page](https://github.com/rear/rear/wiki/Coding-Style)
 
 
-### Mailinglists
-The Relax-and-Recover project offers three mailinglists:
-
- - [rear-announce mailinglist](http://lists.relax-and-recover.org/mailman/listinfo/rear-announce)
-   used for release announcements
- - [rear-users mailinglist](http://lists.relax-and-recover.org/mailman/listinfo/rear-users)
-   used for end-user support
- - [rear-devel mailinglist](http://lists.relax-and-recover.org/mailman/listinfo/rear-devel)
-   used for development discussions
-
 
 ### Reporting issues
 The Github interface enables users to report issues or discuss improvements
-and new features through the issue-tracker at:
-<http://github.com/rear/rear/issues>
+and new features through the issue-tracker at <http://github.com/rear/rear/issues>
+
+For new issues or features use the
+[New issue](http://github.com/rear/rear/issues)
+button and fill in your information as needed.
 
 Once reported, one of the contributors can assign it to someone, classify it
 and attached it to a milestone release. Managing issues in this manner helps

--- a/support/index.md
+++ b/support/index.md
@@ -3,10 +3,9 @@ layout: default
 title: Relax-and-Recover support
 ---
 ## Community support
-For voluntary community support, you can use the
-[issue-tracker](http://github.com/rear/rear/issues), the
-[rear-users mailinglist](http://lists.relax-and-recover.org/mailman/listinfo/rear-users)
-or the [chat channel](https://gitter.im/rear/rear).
+For voluntary community support open an issue via the
+[New issue](http://github.com/rear/rear/issues)
+button at GitHub and fill in the needed information.
 
 Please visit the [Development](/development/) page for information on
 how to collaborate on the project and discuss issues.


### PR DESCRIPTION
For voluntary community support show only
to open an issue via the [New issue] button
at GitHub - i.e. do no longer show mailing lists
or chat channels, see
https://github.com/rear/rear/issues/3226